### PR TITLE
Fix issue #1 by adding a required Company field

### DIFF
--- a/src/classes/PubSubServiceTest.cls
+++ b/src/classes/PubSubServiceTest.cls
@@ -20,7 +20,8 @@ private class PubSubServiceTest {
 
         Lead testLead = new Lead(
                 FirstName = 'TestLead',
-                LastName = 'Tester');
+                LastName = 'Tester',
+                Company = 'TestCompany');
 
         IHandleMessages testHandler = new IncomingContactHandler();
         IHandleMessages testHandler2 = new IncomingLeadWithObjectChannelHandler();


### PR DESCRIPTION
It appears that the required field, `Company` is missing from this test case:

https://github.com/blackthornio/sf-code-exercise-public/blob/15f480a36d147c714027c0689c83193817030bde/src/classes/PubSubServiceTest.cls#L21-L23

When the test method `handleMessage_withContact_expectInsertedWithAlteredAssistantName` is run...

https://github.com/blackthornio/sf-code-exercise-public/blob/15f480a36d147c714027c0689c83193817030bde/src/classes/PubSubServiceTest.cls#L15

...it will invoke `IncomingLeadWithObjectChannelHandler` registered in it:

https://github.com/blackthornio/sf-code-exercise-public/blob/15f480a36d147c714027c0689c83193817030bde/src/classes/PubSubServiceTest.cls#L25-L30

https://github.com/blackthornio/sf-code-exercise-public/blob/15f480a36d147c714027c0689c83193817030bde/src/classes/PubSubServiceTest.cls#L38-L41

However, as the `Lead` is missing a `Company` field, this test should always fail, before gets to asserts that test functionality.

Adding the `Company` resolves the issue and the test is fixed.